### PR TITLE
Fix installation section package names in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ If you are first-time user of the Storyblok, read [Nuxt Getting Started](https:/
 ### Installation
 
 ```bash
-npm install --save-dev nuxt-storyblok axios
-// yarn add nuxt-storyblok axios
+npm install --save-dev storyblok-nuxt axios
+// yarn add storyblok-nuxt axios
 ```
 
 > *Hint: You don't have to install Axios if you already installed Axios module of Nuxt.*


### PR DESCRIPTION
The package name is `storyblok-nuxt` not `nuxt-storyblok` 🙃 