### PR TITLE
feat(useAsyncStoryblok): Allow SSR SSG generation by default

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           DEPENDENCY: "@storyblok/vue"
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.DEPENDABOT_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -168,13 +168,15 @@ You can easily render rich text by using the `renderRichText` function that come
 
 ### API
 
-#### useStoryblok(slug, apiOptions, bridgeOptions)
+#### useAsyncStoryblok(slug, apiOptions, bridgeOptions)
+
+(Recommended Option) Use [`useAsyncData`](https://v3.nuxtjs.org/api/composables/use-async-data/) and [`useState`](https://v3.nuxtjs.org/api/composables/use-state) under the hood for generating SSR or SSG applications.
 
 Check the available [apiOptions](https://github.com/storyblok/storyblok-js-client#class-storyblok) (passed to `storyblok-js-client`) and [bridgeOptions](https://www.storyblok.com/docs/Guides/storyblok-latest-js?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-nuxt) (passed to the Storyblok Bridge).
 
-#### useAsyncStoryblok(slug, apiOptions, bridgeOptions)
+#### useStoryblok(slug, apiOptions, bridgeOptions)
 
-Same implementation as `useStoryblok` using [`useAsyncData`](https://v3.nuxtjs.org/api/composables/use-async-data/) and [`useState`](https://v3.nuxtjs.org/api/composables/use-state) for genereting SSR or SSG applications.
+It could be helpful to use `useStoryblok` instead of `useAsyncStoryblok` when we need to make client-side requests, for example, getting personalized data for a logged user.
 
 Check the available [apiOptions](https://github.com/storyblok/storyblok-js-client#class-storyblok) (passed to `storyblok-js-client`) and [bridgeOptions](https://www.storyblok.com/docs/Guides/storyblok-latest-js?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-nuxt) (passed to the Storyblok Bridge).
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ You can easily render rich text by using the `renderRichText` function that come
 
 Check the available [apiOptions](https://github.com/storyblok/storyblok-js-client#class-storyblok) (passed to `storyblok-js-client`) and [bridgeOptions](https://www.storyblok.com/docs/Guides/storyblok-latest-js?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-nuxt) (passed to the Storyblok Bridge).
 
+#### useAsyncStoryblok(slug, apiOptions, bridgeOptions)
+
+Same implementation as `useStoryblok` using [`useAsyncData`](https://v3.nuxtjs.org/api/composables/use-async-data/) and [`useState`](https://v3.nuxtjs.org/api/composables/use-state) for genereting SSR or SSG applications.
+
+Check the available [apiOptions](https://github.com/storyblok/storyblok-js-client#class-storyblok) (passed to `storyblok-js-client`) and [bridgeOptions](https://www.storyblok.com/docs/Guides/storyblok-latest-js?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-nuxt) (passed to the Storyblok Bridge).
+
 #### useStoryblokApi()
 
 Returns the instance of the `storyblok-js-client`.

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ To link your Vue components to their equivalent you created in Storyblok:
 
 #### Composition API
 
-The simplest way is by using the `useStoryblok` one-liner composable (it's autoimported) and passing as a first parameter a name of your content page from Storyblok (in this case, our content page name is `vue`, by default you get a content page named `home`):
+The simplest way is by using the `useAsyncStoryblok` one-liner composable (it's autoimported) and passing as a first parameter a name of your content page from Storyblok (in this case, our content page name is `vue`, by default you get a content page named `home`):
 
 ```html
 <script setup>
-  const story = await useStoryblok("vue", { version: "draft" });
+  const story = await useAsyncStoryblok("vue", { version: "draft" });
 </script>
 
 <template>
@@ -126,16 +126,19 @@ The simplest way is by using the `useStoryblok` one-liner composable (it's autoi
 </template>
 ```
 
-Which is the short-hand equivalent to using `useStoryblokApi` and `useStoryblokBridge` functions separately:
+Which is the short-hand equivalent to using `useStoryblokApi` inside `useAsyncData` and `useStoryblokBridge` functions separately:
 
 ```html
 <script setup>
   const story = ref(null);
   const storyblokApi = useStoryblokApi();
-  const { data } = await storyblokApi.get("cdn/stories/vue", {
+  const { data } = await useAsyncData(
+    'vue',
+    async () => await storyblokApi.get(`cdn/stories/vue`, {
     version: "draft"
-  });
-  story.value = data.story;
+  })
+  );
+  story.value = data.value.data.story;
 
   onMounted(() => {
     useStoryblokBridge(story.value.id, (evStory) => (story.value = evStory));
@@ -146,6 +149,8 @@ Which is the short-hand equivalent to using `useStoryblokApi` and `useStoryblokB
   <StoryblokComponent v-if="story" :blok="story.content" />
 </template>
 ```
+
+> Using `useAsyncData` SSR and SSG capabilities are enabled.
 
 #### Rendering Rich Text
 

--- a/lib/src/module.js
+++ b/lib/src/module.js
@@ -5,7 +5,8 @@ import {
   defineNuxtModule,
   addPlugin,
   addComponentsDir,
-  addAutoImport
+  addAutoImport,
+  addAutoImportDir
 } from "@nuxt/kit";
 
 export default defineNuxtModule({
@@ -46,5 +47,6 @@ export default defineNuxtModule({
     names.forEach((name) =>
       addAutoImport({ name, as: name, from: "@storyblok/vue" })
     );
+    addAutoImportDir(resolve(runtimeDir, `./composables`));
   }
 });

--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -1,0 +1,29 @@
+import { useStoryblokApi, useStoryblokBridge } from "@storyblok/vue";
+import { useAsyncData, useState, onMounted } from "#imports";
+
+export const useAsyncStoryblok = async (
+  url,
+  apiOptions = {},
+  bridgeOptions = {}
+) => {
+  const story = useState(url, () => null);
+  const storyblokApiInstance = useStoryblokApi();
+
+  onMounted(() => {
+    if (story.value && story.value.id) {
+      useStoryblokBridge(
+        story.value.id,
+        (evStory) => (story.value = evStory),
+        bridgeOptions
+      );
+    }
+  });
+
+  const { data } = await useAsyncData(
+    url,
+    async () => await storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions)
+  );
+  story.value = data.value.data.story;
+
+  return story;
+};

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,9 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "demo": "nuxi dev",
-    "build": "nuxi build",
-    "start": "node .output/server/index.mjs"
+    "demo": "nuxt dev",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "start": "nuxt preview"
   },
   "devDependencies": {
     "nuxt": "^3.0.0-rc.9",

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,7 +1,6 @@
 <script setup>
-const story = await useStoryblok("vue", { version: "draft" });
+const story = await useAsyncStoryblok("vue", { version: "draft" });
 const richText = computed(() => renderRichText(story.value.content.richText));
-console.log(richText);
 </script>
 
 <template>


### PR DESCRIPTION
Changes:

- Create `useAsyncStoryblok` composable using `useAsyncData` and `useState` for static and server builds.
- Add autoImportDir for the new `composables` folder.
- Update README.
- Use the composable in the playground by default.
- Update nuxt commands.