### PR TITLE
fix: adds proper isPreview check based on route query to prevent incorrect console log about draft/preview

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -1,5 +1,5 @@
 import { useStoryblokApi, useStoryblokBridge } from "@storyblok/vue";
-import { useAsyncData, useState, onMounted } from "#imports";
+import { useAsyncData, useState, onMounted, useRoute } from "#imports";
 
 export const useAsyncStoryblok = async (
   url,
@@ -8,9 +8,11 @@ export const useAsyncStoryblok = async (
 ) => {
   const story = useState(url, () => null);
   const storyblokApiInstance = useStoryblokApi();
+  const route = useRoute();
+  const isPreview = !!(route.query._storyblok && route.query._storyblok !== '');
 
   onMounted(() => {
-    if (story.value && story.value.id) {
+    if (isPreview && story.value && story.value.id) {
       useStoryblokBridge(
         story.value.id,
         (evStory) => (story.value = evStory),


### PR DESCRIPTION
Checks against `_storyblok` to make sure that we only print the warning if the user is actually not in preview.