### PR TITLE
fix: add apiOptions to the unique key

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -6,7 +6,8 @@ export const useAsyncStoryblok = async (
   apiOptions = {},
   bridgeOptions = {}
 ) => {
-  const story = useState(url, () => null);
+  const uniqueKey = `${JSON.stringify(apiOptions)}${url}`;
+  const story = useState(`${uniqueKey}-state`, () => null);
   const storyblokApiInstance = useStoryblokApi();
 
   onMounted(() => {
@@ -19,10 +20,8 @@ export const useAsyncStoryblok = async (
     }
   });
 
-  const hash = JSON.stringify(apiOptions);
-
   const { data } = await useAsyncData(
-    `${hash}-${url}`,
+    `${uniqueKey}-asyncdata`,
     async () => await storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions)
   );
   story.value = data.value.data.story;

--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -19,8 +19,10 @@ export const useAsyncStoryblok = async (
     }
   });
 
+  const hash = JSON.stringify(apiOptions);
+
   const { data } = await useAsyncData(
-    url,
+    `${hash}-${url}`,
     async () => await storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions)
   );
   story.value = data.value.data.story;

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,5 +1,9 @@
 <script setup>
-const story = await useAsyncStoryblok("vue", { version: "draft" });
+const story = await useAsyncStoryblok("vue", {
+  version: "draft",
+  language: "en",
+  resolve_relations: ["popular-articles.articles"]
+});
 const richText = computed(() => renderRichText(story.value.content.richText));
 </script>
 


### PR DESCRIPTION
**Fix:** Create a unique key for `useState` & `useAsyncData` using the `apiOptions`.

**Context:** When changing parameters only in `apiOptions`, not in the slug, Nuxt unique keys were the same for multiple page instances. A good example is using the field-level translation, it's not working or generated properly because of this.
