### PR TITLE
Adds a check for errors on useAsyncStoryblok to prevent errors from gettting to clients.

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -19,11 +19,14 @@ export const useAsyncStoryblok = async (
     }
   });
 
-  const { data } = await useAsyncData(
+  const { data, error } = await useAsyncData(
     url,
     async () => await storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions)
   );
-  story.value = data.value.data.story;
+  if (!error.value && data.value) {
+    story.value = data.value.data.story;
 
-  return story;
+    return story;
+  }
+  return false;
 };


### PR DESCRIPTION
This change adds a check agains the `error` object coming from `useAsyncData` to prevent axios errors getting down to the client.
This is how it looks without the check:
![image](https://user-images.githubusercontent.com/5083273/208649384-2cc94a28-7e4f-4918-b99a-6a21cb7da397.png)
With the check:
![image](https://user-images.githubusercontent.com/5083273/208649782-2fe96439-4d85-47e0-98e4-a325d0d8d64e.png)

This changes has been tested against my [content project](https://github.com/SebbeJohansson/Vrtx.ContentSystem/blob/main/composables/useStoryblokFetch.ts#L35-L45).

Note:
I am not sure on the method to check if a proper result is enough or if you have a more preferred way of doing it.