### PR TITLE
Throw 404 error if story was not found

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -1,5 +1,5 @@
 import { useStoryblokApi, useStoryblokBridge } from "@storyblok/vue";
-import { useAsyncData, useState, onMounted } from "#imports";
+import { useAsyncData, useState, onMounted, createError } from "#imports";
 
 export const useAsyncStoryblok = async (
   url,
@@ -24,6 +24,15 @@ export const useAsyncStoryblok = async (
     `${uniqueKey}-asyncdata`,
     async () => await storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions)
   );
+  
+  if (error.value?.response.status === 404) {
+    throw createError({
+      statusCode: 404,
+      fatal: true,
+      statusMessage: 'Story not found'
+    });
+  }
+  
   story.value = data.value.data.story;
 
   return story;


### PR DESCRIPTION
At this moment the 404 page ([~/error.vue](https://nuxt.com/docs/getting-started/error-handling#rendering-an-error-page)) doesn't show because useAsyncStoryblok doesn't throw an error. Therefore it only shows a console error and an empty page.

I used the Nuxt createError function to throw an error if the response has a 404 status code.

[https://nuxt.com/docs/getting-started/error-handling#createerror](https://nuxt.com/docs/getting-started/error-handling#createerror)