### PR TITLE
Correct renderRichText() argument in the Rendering Rich Text section of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can easily render rich text by using the `renderRichText` function that come
 
 <script setup>
   const props = defineProps({ blok: Object })
-  const articleContent = computed(() => renderRichText(blok.articleContent));
+  const articleContent = computed(() => renderRichText(props.blok.articleContent));
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can easily render rich text by using the `renderRichText` function that come
 </template>
 
 <script setup>
-  const props = defineProps({ blok: Object })
+  const props = defineProps({ blok: Object });
   const articleContent = computed(() => renderRichText(props.blok.articleContent));
 </script>
 ```
@@ -187,7 +187,7 @@ You can also set a **custom Schema and component resolver** by passing the optio
       resolver: (component, blok) => {
         switch (component) {
           case "my-custom-component":
-            return `<div class="my-component-class">${blok.text}</div>`;
+            return `<div class="my-component-class">${props.blok.text}</div>`;
           default:
             return "Resolver not defined";
         }


### PR DESCRIPTION
I found a little mistake that might be worth fixing, just in case any other person runs into the same issue I was having. I haven’t used Vue for quite a while, so it wasn’t easy for me to notice what was missing :P