### PR TITLE
fix: add export default to fix the TypeScript declaration when build

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.js
+++ b/lib/src/runtime/composables/useAsyncStoryblok.js
@@ -1,11 +1,7 @@
 import { useStoryblokApi, useStoryblokBridge } from "@storyblok/vue";
 import { useAsyncData, useState, onMounted } from "#imports";
 
-export const useAsyncStoryblok = async (
-  url,
-  apiOptions = {},
-  bridgeOptions = {}
-) => {
+const useAsyncStoryblok = async (url, apiOptions = {}, bridgeOptions = {}) => {
   const uniqueKey = `${JSON.stringify(apiOptions)}${url}`;
   const story = useState(`${uniqueKey}-state`, () => null);
   const storyblokApiInstance = useStoryblokApi();
@@ -28,3 +24,5 @@ export const useAsyncStoryblok = async (
 
   return story;
 };
+
+export default useAsyncStoryblok;


### PR DESCRIPTION
The module built was causing duplicate imports due to the d.ts file exporting the function but not declaring it.

This PR will solve and close issue #282.