### PR TITLE
fix: correctly checks so that error value exists before trying to show one in useAsyncStoryblok

### DIFF
--- a/lib/src/runtime/composables/useAsyncStoryblok.ts
+++ b/lib/src/runtime/composables/useAsyncStoryblok.ts
@@ -26,8 +26,6 @@ export const useAsyncStoryblok = async (
     () => storyblokApiInstance.get(`cdn/stories/${url}`, apiOptions),
   );
 
-  if (error.value?.response.status >= 400 && error.value?.response.status < 600) {
-    throw createError({ statusCode: error.value?.response.status, statusMessage: error.value?.message.message });
   if (error.value?.response && error.value?.response.status >= 400 && error.value?.response.status < 600) {
     throw createError({ statusCode: error.value?.response.status, statusMessage: error.value?.message?.message || 'Something went wrong when fetching from storyblok.' });
   }

--- a/lib/src/runtime/composables/useAsyncStoryblok.ts
+++ b/lib/src/runtime/composables/useAsyncStoryblok.ts
@@ -28,6 +28,8 @@ export const useAsyncStoryblok = async (
 
   if (error.value?.response.status >= 400 && error.value?.response.status < 600) {
     throw createError({ statusCode: error.value?.response.status, statusMessage: error.value?.message.message });
+  if (error.value?.response && error.value?.response.status >= 400 && error.value?.response.status < 600) {
+    throw createError({ statusCode: error.value?.response.status, statusMessage: error.value?.message?.message || 'Something went wrong when fetching from storyblok.' });
   }
 
   story.value = data.value?.data.story;

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "nuxt": "^3.0.0",
-    "@storyblok/nuxt": "^0.0.1"
+    "@storyblok/nuxt": "file:../"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "nuxt": "^3.0.0",
-    "@storyblok/nuxt": "file:../"
+    "@storyblok/nuxt": "^0.0.1"
   }
 }

--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -1,0 +1,20 @@
+<script setup>
+const route = useRoute();
+
+const story = ref();
+try {
+  story.value = await useAsyncStoryblok(route.path, {
+    version: "draft",
+    language: "en",
+    resolve_relations: ["popular-articles.articles"]
+  });
+} catch (error) {
+  console.log(error);
+}
+</script>
+
+<template>
+  <div>
+    {{ story }}
+  </div>
+</template>


### PR DESCRIPTION
* Fix: Checks so that `error.value?.response` is true-ish before trying to display an error with nuxt - #210 
* Feat: Changes how the playground refers to the module so that its easier to debug.
* Feat: Adds a slug fallback page so that its possible to test against 404 slugs.