### PR TITLE
docs: upgrade readme with regions and props fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ export default defineNuxtConfig({
 
 When you initialize the module, you can pass all [_@storyblok/vue_ options](https://github.com/storyblok/storyblok-vue#storyblok-api) plus a `bridge` option explained in our [JS SDK Storyblok bridge section](https://github.com/storyblok/storyblok-js#storyblok-bridge).
 
-> Note: For spaces created in the United States, you have to set the `region` parameter accordingly `{ apiOptions: { region: 'us' } }`.
-
 ```js
 // Defaults
 ["@storyblok/nuxt", {
@@ -90,6 +88,27 @@ When you initialize the module, you can pass all [_@storyblok/vue_ options](http
   }
 }]
 ```
+
+#### Region parameter
+
+Possible values:
+
+- `eu` (default): For spaces created in the EU
+- `us`: For spaces created in the US
+- `cn`: For spaces created in China
+
+Full example for a space created in the US:
+
+```js
+storyblok({
+  accessToken: "<your-access-token>",
+  apiOptions: {
+    region: "us"
+  }
+});
+```
+
+> Note: For spaces created in the United States or China, the `region` parameter **must** be specified.
 
 ### Getting started
 
@@ -172,7 +191,9 @@ You can easily render rich text by using the `renderRichText` function that come
 
 <script setup>
   const props = defineProps({ blok: Object });
-  const articleContent = computed(() => renderRichText(blok.articleContent));
+  const articleContent = computed(() =>
+    renderRichText(props.blok.articleContent)
+  );
 </script>
 ```
 
@@ -235,6 +256,10 @@ Returns the instance of the `storyblok-js-client`.
 #### useStoryblokBridge(storyId, callback, bridgeOptions)
 
 Use this one-line function to cover the most common use case: updating the story when any kind of change happens on Storyblok Visual Editor.
+
+## The Storyblok JavaScript SDK Ecosystem
+
+![A visual representation of the Storyblok JavaScript SDK Ecosystem](https://a.storyblok.com/f/88751/2400x1350/be4a4a4180/sdk-ecosystem.png/m/1200x0)
 
 ## 🔗 Related Links
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,14 @@ Possible values:
 Full example for a space created in the US:
 
 ```js
-storyblok({
-  accessToken: "<your-access-token>",
-  apiOptions: {
-    region: "us"
+["@storyblok/nuxt", {
+  {
+    accessToken: "<your-access-token>",
+    apiOptions: {
+      region: "us"
+    }
   }
-});
+}]
 ```
 
 > Note: For spaces created in the United States or China, the `region` parameter **must** be specified.

--- a/lib/README.md
+++ b/lib/README.md
@@ -78,8 +78,6 @@ export default defineNuxtConfig({
 
 When you initialize the module, you can pass all [_@storyblok/vue_ options](https://github.com/storyblok/storyblok-vue#storyblok-api) plus a `bridge` option explained in our [JS SDK Storyblok bridge section](https://github.com/storyblok/storyblok-js#storyblok-bridge).
 
-> Note: For spaces created in the United States, you have to set the `region` parameter accordingly `{ apiOptions: { region: 'us' } }`.
-
 ```js
 // Defaults
 ["@storyblok/nuxt", {
@@ -90,6 +88,27 @@ When you initialize the module, you can pass all [_@storyblok/vue_ options](http
   }
 }]
 ```
+
+#### Region parameter
+
+Possible values:
+
+- `eu` (default): For spaces created in the EU
+- `us`: For spaces created in the US
+- `cn`: For spaces created in China
+
+Full example for a space created in the US:
+
+```js
+storyblok({
+  accessToken: "<your-access-token>",
+  apiOptions: {
+    region: "us"
+  }
+});
+```
+
+> Note: For spaces created in the United States or China, the `region` parameter **must** be specified.
 
 ### Getting started
 
@@ -172,7 +191,9 @@ You can easily render rich text by using the `renderRichText` function that come
 
 <script setup>
   const props = defineProps({ blok: Object });
-  const articleContent = computed(() => renderRichText(blok.articleContent));
+  const articleContent = computed(() =>
+    renderRichText(props.blok.articleContent)
+  );
 </script>
 ```
 
@@ -235,6 +256,10 @@ Returns the instance of the `storyblok-js-client`.
 #### useStoryblokBridge(storyId, callback, bridgeOptions)
 
 Use this one-line function to cover the most common use case: updating the story when any kind of change happens on Storyblok Visual Editor.
+
+## The Storyblok JavaScript SDK Ecosystem
+
+![A visual representation of the Storyblok JavaScript SDK Ecosystem](https://a.storyblok.com/f/88751/2400x1350/be4a4a4180/sdk-ecosystem.png/m/1200x0)
 
 ## 🔗 Related Links
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -100,12 +100,14 @@ Possible values:
 Full example for a space created in the US:
 
 ```js
-storyblok({
-  accessToken: "<your-access-token>",
-  apiOptions: {
-    region: "us"
+["@storyblok/nuxt", {
+  {
+    accessToken: "<your-access-token>",
+    apiOptions: {
+      region: "us"
+    }
   }
-});
+}]
 ```
 
 > Note: For spaces created in the United States or China, the `region` parameter **must** be specified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.5.1",
         "@commitlint/config-conventional": "^17.4.4",
-        "@nuxtjs/eslint-config-typescript": "*",
+        "@nuxtjs/eslint-config-typescript": "latest",
         "eslint": "^8.37.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-vue": "^9.9.0",
@@ -33,7 +33,7 @@
       "devDependencies": {
         "@babel/core": "^7.21.0",
         "@cypress/vite-dev-server": "^5.0.5",
-        "@nuxt/module-builder": "*",
+        "@nuxt/module-builder": "latest",
         "babel-jest": "^29.4.3",
         "cypress": "^12.9.0",
         "eslint-plugin-cypress": "^2.13.2",
@@ -19032,7 +19032,7 @@
         "@babel/core": "^7.21.0",
         "@cypress/vite-dev-server": "^5.0.5",
         "@nuxt/kit": "^3.3.2",
-        "@nuxt/module-builder": "*",
+        "@nuxt/module-builder": "latest",
         "@storyblok/vue": "^7.1.2",
         "babel-jest": "^29.4.3",
         "cypress": "^12.9.0",


### PR DESCRIPTION
- Add Regions section
- Add the Storyblok JS ecosystem diagram
- Fix the typo missing the `props.blok` mentioned in an issue. This PR close #335 