### PR TITLE
fix(): useRuntimeConfig should use the .public property

### DIFF
--- a/lib/src/runtime/plugin.ts
+++ b/lib/src/runtime/plugin.ts
@@ -2,7 +2,7 @@ import { StoryblokVue, apiPlugin } from "@storyblok/vue";
 import { defineNuxtPlugin, useRuntimeConfig } from "#app";
 
 export default defineNuxtPlugin(({ vueApp }) => {
-  let { storyblok } = useRuntimeConfig();
+  let { storyblok } = useRuntimeConfig().public;
   storyblok = JSON.parse(JSON.stringify(storyblok));
   vueApp.use(StoryblokVue, { ...storyblok, use: [apiPlugin] });
 });


### PR DESCRIPTION
[Nuxt v3.4](https://github.com/nuxt/nuxt/releases/tag/v3.4.0) introduced a warning for using public environmental variables without the .public property. In v3.5, it will be removed entirely.

Simply adding the .public property should solve this.