### PR TITLE
fix: include `dist/` files in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
       "require": "./dist/module.cjs"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "prepack": "nuxt-module-build",
     "build": "nuxt-module-build",


### PR DESCRIPTION
Currently no `dist/` files are present in published package: https://unpkg.com/browse/@storyblok/nuxt@5.6.1/

This change publishes them.

If you also want to include src/ files/directory, we can add other patterns explicitly to the array.

You can test this locally (before/after) by running:

```sh
npm pack
tar tzvf storyblok-nuxt-0.0.1.tgz
# prints list of files to be published
```

resolves https://github.com/storyblok/storyblok-nuxt/issues/514