### PR TITLE
feat: optional / configurable global directory

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -15,6 +15,7 @@ export interface ModuleOptions {
   bridge: boolean, // storyblok bridge on/off
   devtools: boolean, // enable nuxt/devtools integration
   apiOptions: any, // storyblok-js-client options
+  globalDir: string, // enable storyblok global directory for components
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -28,6 +29,7 @@ export default defineNuxtModule<ModuleOptions>({
     usePlugin: true, // legacy opt. for enableSudoMode
     bridge: true,
     devtools: false,
+    globalDir: '~/storyblok',
     apiOptions: {},
   },
   setup(options, nuxt) {
@@ -47,8 +49,9 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Enable dirs
     // nuxt.options.components.dirs = ["~/components/storyblok"];
-    addComponentsDir({ path: "~/storyblok", global: true, pathPrefix: false });
-
+    if(options.globalDir){
+      addComponentsDir({ path: options.globalDir, global: true, pathPrefix: false });
+    }
     nuxt.options.build.transpile.push(resolver.resolve("./runtime"));
     nuxt.options.build.transpile.push("@storyblok/nuxt");
     nuxt.options.build.transpile.push("@storyblok/vue");


### PR DESCRIPTION
# Global Storyblok Directory (optional/configurable)

## Use Case

To define a "own" storyblok directory for modules or deactivate it completely when implementing a custom logic for whatever reason. E.g custom resolve components logic without adding global components. 