### PR TITLE
fix: do not optimise module code

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -38,7 +38,6 @@ export default defineNuxtModule<ModuleOptions>({
     if(nuxt.options.vite.optimizeDeps) {
       nuxt.options.vite.optimizeDeps.include =
         nuxt.options.vite.optimizeDeps.include || [];
-      nuxt.options.vite.optimizeDeps.include.push("@storyblok/nuxt");
       nuxt.options.vite.optimizeDeps.include.push("@storyblok/vue");
 
       nuxt.options.vite.optimizeDeps.exclude =


### PR DESCRIPTION
https://github.com/nuxt/nuxt/issues/24387
resolves https://github.com/storyblok/storyblok-nuxt/issues/660 

When vite optimises code, it will crawl that code in a runtime context. But Nuxt modules are always meant to be run in a module context. By removing this we speed up the start of Nuxt for users using storyblok, and also avoid errors caused by trying to resolve Nuxt module imports outside of a Node context.