### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Install `@storyblok/nuxt`:
 
 ```bash
 npx nuxi@latest module add storyblok
-# npx nuxi@latest module add storyblok
 ```
 
 Add following code to modules section of `nuxt.config.js` and replace the accessToken with API token from Storyblok space.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ If you are in a hurry, check out our official **[live demo](https://stackblitz.c
 Install `@storyblok/nuxt`:
 
 ```bash
-npm install @storyblok/nuxt
-# yarn add @storyblok/nuxt
+npx nuxi@latest module add storyblok
+# npx nuxi@latest module add storyblok
 ```
 
 Add following code to modules section of `nuxt.config.js` and replace the accessToken with API token from Storyblok space.


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
