### PR TITLE
feat: allow asyncOptions

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -16,6 +16,7 @@ export interface ModuleOptions {
   devtools: boolean, // enable nuxt/devtools integration
   apiOptions: any, // storyblok-js-client options
   componentsDir: string, // enable storyblok global directory for components
+  asyncDataOutput: boolean, // enable asyncData output, will become default
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -31,6 +32,7 @@ export default defineNuxtModule<ModuleOptions>({
     devtools: false,
     componentsDir: '~/storyblok',
     apiOptions: {},
+    asyncDataOutput: false,
   },
   setup(options, nuxt) {
     const resolver = createResolver(import.meta.url);

--- a/src/runtime/composables/useAsyncStoryblok.ts
+++ b/src/runtime/composables/useAsyncStoryblok.ts
@@ -1,11 +1,14 @@
 import { useStoryblokApi, useStoryblokBridge } from "@storyblok/vue";
 import type { ISbStoriesParams, StoryblokBridgeConfigV2, ISbStoryData } from '@storyblok/vue';
-import { useState, onMounted, useAsyncData } from "#imports";
+import { useState, onMounted, useAsyncData, useRuntimeConfig } from "#imports";
+import { type AsyncDataOptions } from "#imports";
+import deprecate from "util-deprecate";
 
 export const useAsyncStoryblok = async (
   url: string,
   apiOptions: ISbStoriesParams = {},
-  bridgeOptions: StoryblokBridgeConfigV2 = {}
+  bridgeOptions: StoryblokBridgeConfigV2 = {},
+  asyncOptions: AsyncDataOptions = undefined
 ) => {
   const storyblokApiInstance = useStoryblokApi();
   const uniqueKey = `${JSON.stringify(apiOptions)}${url}`;
@@ -21,16 +24,31 @@ export const useAsyncStoryblok = async (
     }
   });
 
-  if (!story.value) {
-    const { data } = await useAsyncData(uniqueKey, () => {
-      return storyblokApiInstance.get(
-        `cdn/stories/${url}`,
-        apiOptions
-      );
-    })
-    if(data) {
-      story.value = data.value?.data.story
+  const options = useRuntimeConfig().public.storyblok;
+  if (!options.asyncDataOutput && asyncOptions === undefined) {
+    if (!story.value) {
+      deprecate(() => {}, "`useAsyncStoryblok` will return an `AsyncData` object ({ data, pending, ... }) in the future. You can change this behavior now by passing an AsyncDataOptions object as the last argument or setting `asyncDataOutput: true` in module options in `nuxt.config`.", "STORYBLOK-DEPR-ASYNC")();
+      const { data } = await useAsyncData(uniqueKey, () => {
+        return storyblokApiInstance.get(
+          `cdn/stories/${url}`,
+          apiOptions
+        );
+      })
+      if(data) {
+        story.value = data.value?.data.story
+      }
     }
+
+    return story
   }
-  return story
+
+  return await useAsyncData(
+    uniqueKey,
+    () => {
+      return storyblokApiInstance
+        .get(`cdn/stories/${url}`, apiOptions)
+        .then((r) => r.data.story)
+    },
+    asyncOptions
+  )
 };


### PR DESCRIPTION
Allows adding `asyncDataOptions` into the `useAsyncStoryblok` call. In this case returns an `AsyncData` object instead of raw story value.

Print deprecation warning as this will be a breaking change.