### PR TITLE
docs: fix wrong fallback example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ Check the available [apiOptions](https://www.storyblok.com/docs/api/content-deli
     { resolveRelations: ["Article.author"], resolveLinks: "url" } // Bridge Options
   );
 
-  if (story.value.status) {
+  if (!story.value) {
     throw createError({
-      statusCode: story.value.status,
-      statusMessage: story.value.response
+      statusCode: 404,
+      message: 'not found',
     });
   }
 </script>


### PR DESCRIPTION
There is an example in the readme that uses `story.value.status` from `useAsyncStoryblok` to determine if a story has been found. This property as well as `story.value.response` doesn't exists for me though.

Without proper typings, this is annoying to detect. I was about to use this when I discovered PR #833 and noticed, that these properties are missing,