### PR TITLE
fix: fake change to force new version to be able to use pkg.pr.new

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,6 +1,8 @@
 import { apiPlugin, StoryblokVue } from '@storyblok/vue';
 import { defineNuxtPlugin, useRuntimeConfig } from '#app';
 
+// TODO: This comment is used to generate a new version with semantic release, remove it on next version
+
 export default defineNuxtPlugin(({ vueApp }) => {
   let { storyblok } = useRuntimeConfig().public;
   storyblok = JSON.parse(JSON.stringify(storyblok));


### PR DESCRIPTION
This PR adds a comment with a `fix` commit so it forces a release to be able to use pkg.pr.new further

Ignore it, it adds no value