### PR TITLE
feat!: removed legacy richtext and updated related deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,52 +355,6 @@ If you want to use the `useStoryblokRichText` composable, you can pass the `reso
 </script>
 ```
 
-### Legacy Rendering Rich Text
-
-> [!WARNING]  
-> The legacy `richTextResolver` is soon to be deprecated. We recommend migrating to the new approach described above instead.
-
-You can easily render rich text by using the `renderRichText` function that comes with `@storyblok/nuxt` and a Vue computed property:
-
-```html
-<template>
-  <div v-html="articleContent"></div>
-</template>
-
-<script setup>
-  const props = defineProps({ blok: Object });
-  const articleContent = computed(() => renderRichText(props.blok.articleContent));
-</script>
-```
-
-You can also set a **custom Schema and component resolver** by passing the options as the second parameter of the `renderRichText` function:
-
-```html
-<script setup>
-  import cloneDeep from 'clone-deep';
-
-  const mySchema = cloneDeep(RichTextSchema); // you can make a copy of the default RichTextSchema
-  // ... and edit the nodes and marks, or add your own.
-  // Check the base RichTextSchema source here https://github.com/storyblok/storyblok-js-client/blob/v4/source/schema.js
-
-  const props = defineProps({ blok: Object });
-
-  const articleContent = computed(() =>
-    renderRichText(props.blok.articleContent, {
-      schema: mySchema,
-      resolver: (component, blok) => {
-        switch (component) {
-          case 'my-custom-component':
-            return `<div class="my-component-class">${blok.text}</div>`;
-          default:
-            return 'Resolver not defined';
-        }
-      },
-    }),
-  );
-</script>
-```
-
 ## 3. Working with preview and/or production environments
 
 Remember that the bridge only works using `version: 'draft'` and the _Preview Access Token_.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check-licenses": "node scripts/license-checker.mjs"
   },
   "dependencies": {
-    "@storyblok/vue": "^8.1.11"
+    "@storyblok/vue": "^9.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/vue':
-        specifier: ^8.1.11
-        version: 8.2.0(vue@3.5.13(typescript@5.6.2))
+        specifier: ^9.0.0
+        version: 9.0.0(vue@3.5.13(typescript@5.6.2))
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.7.1
@@ -1606,14 +1606,14 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@storyblok/js@3.3.0':
-    resolution: {integrity: sha512-+i0I6nvbCXnfO6L5b5SYvoqLHUb1j3iIznuN/tcGO9c8MYNopY7XGOjrOOTlJVAoiFECJyzYiwC7mDRwrotvfw==}
+  '@storyblok/js@4.0.0':
+    resolution: {integrity: sha512-D3EB9LQ9P9I9WTauwUaBkZ6J8qMVnpUAxPZRbarL7SdDKILD4CAVR9Bn+T6H5znu45J4Zq9P7OvxH+sQZPvgXw==}
 
-  '@storyblok/richtext@3.1.0':
-    resolution: {integrity: sha512-QtH5G+F7w3YuGGnHAFldo71vPpBT5prndZWFPDihlIsWaW0rEWyE9iX+6fp2f4XDgbhi0vyF1HqajFplGOtFVg==}
+  '@storyblok/richtext@3.2.0':
+    resolution: {integrity: sha512-koVGDv1HtiI5vymE5fzRB1VO1PNguj+RSfHI4zCy2+90pRoqZbsUCR8V2TaNl7Pg8R1oOkFZnbAxdt9Z4xoxDg==}
 
-  '@storyblok/vue@8.2.0':
-    resolution: {integrity: sha512-Yi3BFYJkTMm787hTEKMouVYHlNzxUyDChSFgIuhp4XZ4XtMNci4GzvKnZfgzOifxst9h+LRbr9cvuSybqjWbEA==}
+  '@storyblok/vue@9.0.0':
+    resolution: {integrity: sha512-oINPI/ETfOPPJgnIzIsjC2AwYxr93bv/dr1XaCV4hoIcSyUmrxT1TPnFkXO6MveMSzEZqlbX2D+yztQ8B4sdpg==}
     peerDependencies:
       vue: '>=3.4'
 
@@ -5597,8 +5597,8 @@ packages:
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
 
-  storyblok-js-client@6.10.10:
-    resolution: {integrity: sha512-4TK6jZHTJbgbUVCne+2fg6omSmWTWBaBtmDJY0fhBw/BN5flE7wrPU41cU0olVqSbkFNF62WJnoznE1a7pzkKA==}
+  storyblok-js-client@7.0.0:
+    resolution: {integrity: sha512-00zWW3jscL4W1kek9QCrInq1jw4xwjeM0jXuKg4sa/bCT8QuLGaGU9Wn3hat/hkvZLRFC09fV4sJRxDqwsFaKQ==}
 
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
@@ -8147,16 +8147,16 @@ snapshots:
       - typescript
       - vitest
 
-  '@storyblok/js@3.3.0':
+  '@storyblok/js@4.0.0':
     dependencies:
-      '@storyblok/richtext': 3.1.0
-      storyblok-js-client: 6.10.10
+      '@storyblok/richtext': 3.2.0
+      storyblok-js-client: 7.0.0
 
-  '@storyblok/richtext@3.1.0': {}
+  '@storyblok/richtext@3.2.0': {}
 
-  '@storyblok/vue@8.2.0(vue@3.5.13(typescript@5.6.2))':
+  '@storyblok/vue@9.0.0(vue@3.5.13(typescript@5.6.2))':
     dependencies:
-      '@storyblok/js': 3.3.0
+      '@storyblok/js': 4.0.0
       vue: 3.5.13(typescript@5.6.2)
 
   '@stylistic/eslint-plugin@2.13.0(eslint@8.57.1)(typescript@5.6.2)':
@@ -13137,7 +13137,7 @@ snapshots:
 
   std-env@3.8.1: {}
 
-  storyblok-js-client@6.10.10: {}
+  storyblok-js-client@7.0.0: {}
 
   stream-combiner@0.0.4:
     dependencies:

--- a/src/module.ts
+++ b/src/module.ts
@@ -67,7 +67,6 @@ export default defineNuxtModule<ModuleOptions>({
       'useStoryblokApi',
       'useStoryblokBridge',
       'renderRichText',
-      'RichTextSchema',
       'StoryblokRichText',
       'useStoryblokRichText',
       'MarkTypes',


### PR DESCRIPTION
BREAKING CHANGE: `RichTextSchema` is no longer available as export

- Updated @storyblok/vue from 8.1.11 to 9.0.0 in package.json.
- Updated related dependencies in pnpm-lock.yaml, including @storyblok/js to 4.0.0 and storyblok-js-client to 7.0.0.
- Removed deprecated RichTextSchema import from module.ts.
- Cleaned up legacy rendering rich text documentation in README.md.